### PR TITLE
fix: Resolve YAML formatting issues in buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -49,23 +49,10 @@ phases:
       - docker push $REPOSITORY_URI:$IMAGE_TAG
       - docker push $REPOSITORY_URI:latest
       - echo Writing image definitions file...
-      - |
-        cat > imagedefinitions.json << EOF
-        [
-          {
-            "name": "$CONTAINER_NAME",
-            "imageUri": "$REPOSITORY_URI:$IMAGE_TAG"
-          }
-        ]
-        EOF
+      - echo '[{"name":"'$CONTAINER_NAME'","imageUri":"'$REPOSITORY_URI:$IMAGE_TAG'"}]' > imagedefinitions.json
       - cat imagedefinitions.json
       - echo Updating ECS service...
-      - |
-        aws ecs update-service \
-          --cluster $ECS_CLUSTER_NAME \
-          --service $ECS_SERVICE_NAME \
-          --force-new-deployment \
-          --region $AWS_DEFAULT_REGION
+      - aws ecs update-service --cluster $ECS_CLUSTER_NAME --service $ECS_SERVICE_NAME --force-new-deployment --region $AWS_DEFAULT_REGION
       - echo Deployment initiated successfully
 
 artifacts:


### PR DESCRIPTION
- Replace multi-line commands with single-line equivalents
- Fix 'Expected Commands[1] to be of string type' error
- Simplify imagedefinitions.json creation using echo
- Consolidate aws ecs update-service command to single line
- Ensure proper YAML structure for CodeBuild validation