### PR TITLE
refactor: Improve buildspec.yml with better practices

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,12 +1,7 @@
 version: 0.2
 
-# Use standard CodeBuild environment with AWS CLI pre-installed
-runtime-versions:
-  aws-cli: 2
-
 env:
   variables:
-    # Default values - override in CodeBuild project environment
     AWS_DEFAULT_REGION: "us-east-1"
     AWS_ACCOUNT_ID: "123456789012"
     IMAGE_REPO_NAME: "amrti-app"
@@ -23,43 +18,42 @@ phases:
       - echo "Environment variables:"
       - echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
       - echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID"
-      - echo "Checking AWS CLI availability..."
       - which aws || echo "AWS CLI not found in PATH"
       - aws --version || echo "AWS CLI version check failed"
       - echo "Logging in to Amazon ECR..."
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME
-      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - IMAGE_TAG=$COMMIT_HASH
-      - echo Repository URI is $REPOSITORY_URI
-      - echo Image tag is $IMAGE_TAG
+      - export REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME
+      - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - export IMAGE_TAG=$COMMIT_HASH
+      - echo "Repository URI is $REPOSITORY_URI"
+      - echo "Image tag is $IMAGE_TAG"
 
   build:
     commands:
-      - echo Build started on `date`
-      - echo Building the Docker image...
+      - echo "Build started on $(date)"
+      - echo "Building the Docker image..."
       - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $REPOSITORY_URI:latest
 
   post_build:
     commands:
-      - echo Build completed on `date`
-      - echo Pushing the Docker images...
+      - echo "Build completed on $(date)"
+      - echo "Pushing the Docker images..."
       - docker push $REPOSITORY_URI:$IMAGE_TAG
       - docker push $REPOSITORY_URI:latest
-      - echo Writing image definitions file...
+      - echo "Writing image definitions file..."
       - echo '[{"name":"'$CONTAINER_NAME'","imageUri":"'$REPOSITORY_URI:$IMAGE_TAG'"}]' > imagedefinitions.json
       - cat imagedefinitions.json
-      - echo Updating ECS service...
+      - echo "Updating ECS service..."
       - aws ecs update-service --cluster $ECS_CLUSTER_NAME --service $ECS_SERVICE_NAME --force-new-deployment --region $AWS_DEFAULT_REGION
-      - echo Deployment initiated successfully
+      - echo "Deployment initiated successfully"
 
 artifacts:
   files:
     - imagedefinitions.json
     - '**/*'
-  name: amrti-build-$(date +%Y-%m-%d)
+  name: amrti-build
 
 cache:
   paths:


### PR DESCRIPTION
- Remove runtime-versions section (AWS CLI is pre-installed in CodeBuild)
- Add export statements for environment variables to ensure persistence
- Improve echo statements with proper quoting and modern syntax
- Use $(date) instead of backticks for better shell compatibility
- Simplify artifact name to avoid date command issues
- Clean up formatting and remove unnecessary comments
- Ensure all variables are properly exported across build phases